### PR TITLE
add:ページのタイトルを動的に表示するよう修正

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,4 +1,8 @@
 # frozen_string_literal: true
 
 module ApplicationHelper
+  def page_title(title = '')
+    base_title = 'Praise-Diary'
+    title.present? ? "#{title} | #{base_title}" : base_title
+  end
 end

--- a/app/views/diaries/index.html.erb
+++ b/app/views/diaries/index.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:title, t("title.diary_index")) %>
 <div class="container">
   <div class="">
     <div class="">

--- a/app/views/diaries/new.html.erb
+++ b/app/views/diaries/new.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:title, t("title.new_diary")) %>
 <div class="container">
   <div class="row">
     <div class="flex items-center justify-center">

--- a/app/views/diaries/show.html.erb
+++ b/app/views/diaries/show.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:title, @diary.title) %>
 <div class="container pt-5">
   <div class="mb-3">
     <div class="user-name text-center font-black font-bold text-2xl">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title>PraiseDiary</title>
+    <title><%= page_title(yield(:title)) %></title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>     

--- a/app/views/users/sessions/new.html.erb
+++ b/app/views/users/sessions/new.html.erb
@@ -1,3 +1,4 @@
+<% content_for(:title, t("title.login")) %>
 <div class="flex items-center justify-center">
   <h1><%= t("title.login") %></h1>
 </div>

--- a/config/locales/view.ja.yml
+++ b/config/locales/view.ja.yml
@@ -48,7 +48,7 @@ ja:
   title:
     home: ホーム
     search: 検索
-    create_diary: 日記作成
+    new_diary: 日記作成
     memory: 思い出
     mypage: マイページ
     login: ログイン


### PR DESCRIPTION
## 概要
* 各ページのタイトルを動的に表示する機能追加

## 実施内容
* アプリケーションヘルパーのファイルにpage_titleメソッドを作成
```
  def page_title(title = '')
    base_title = 'Praise-Diary'
    title.present? ? "#{title} | #{base_title}" : base_title
  end
```
* 各ビューファイルにて、以下のようにタイトルをpage_titleに渡すような記述を追加
```
<% content_for(:title, t("title.login")) %>
```
* application.html.erbのheadタグに以下を追加
```
<title><%= page_title(yield(:title)) %></title>
```

* ページ遷移した際、それぞれのページタイトルが動的に表示されていることを確認
* 日記詳細ページのタイトルは日記のタイトルになっていることを確認