### PR TITLE
add:いいね数表示をturbo_railsによる非同期処理実装

### DIFF
--- a/app/views/diaries/_diary.html.erb
+++ b/app/views/diaries/_diary.html.erb
@@ -39,17 +39,7 @@
       </div>
     <% end %>
     <div id="like-<%=diary.id%>" class="flex pt-3">
-      <% if current_user && current_user.own?(diary) %>
-        <div id="btn_animation", class="btn_box">
-          <i class="btnn fa-solid fa-heart text-5xl pt-2"></i>
-        </div>
-        <h1 class="text-base mx-7 pt-0"><%= Like.likes_count(diary.id) || 0 %></h1>
-      <% else %>
-        <%= button_to likes_path(diary_id: diary.id), id: "btn_animation", class: "flex btn_box", method: { turbo_method: :post } do %>
-          <i class="btnn fa-solid fa-heart text-5xl pt-2"></i>
-        <% end %>
-        <h1 class="text-base mx-7 pt-0"><%= Like.likes_count(diary.id) || 0 %></h1>
-      <% end %>
+      <%= render partial: "shared/like", locals: {diary: diary} %>
     </div>
   </div>
 </div>

--- a/app/views/diaries/show.html.erb
+++ b/app/views/diaries/show.html.erb
@@ -7,17 +7,7 @@
     <%= render partial: "show_diary", locals: {diary: @diary} %>
   </div>
   <div id="like-<%=@diary.id%>" class="flex pl-20 pt-0">
-    <% if current_user && current_user.own?(@diary) %>
-      <div id="btn_animation", class="btn_box">
-        <i class="btnn fa-solid fa-heart text-5xl pt-2"></i>
-      </div>
-      <h1 class="text-base mx-8 pt-5"><%= Like.likes_count(@diary.id) || 0 %></h1>
-    <% else %>
-      <div id="btn_animation", class="btn_box">
-        <i class="btnn fa-solid fa-heart text-5xl pt-2"></i>
-      </div>
-      <h1 class="text-base mx-8 pt-0"><%= Like.likes_count(@diary.id) || 0 %></h1>
-    <% end %>
+    <%= render partial: "shared/like", locals: {diary: @diary} %>
   </div>
   <%= render partial: "comments/comment", collection: @comments %>
   <%= render partial: "comments/form", locals: {comment: @comment, diary: @diary} %>

--- a/app/views/likes/create.turbo_stream.erb
+++ b/app/views/likes/create.turbo_stream.erb
@@ -1,0 +1,5 @@
+<%= turbo_stream.replace "count-#{@diary.id}" do %>
+  <div id="count-<%=@diary.id%>", class="text-base mx-7 pt-0">
+    <h2><%= Like.likes_count(@diary.id) || 0 %></h2>
+  </div>
+<% end %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -1,39 +1,35 @@
-<header>
-  <nav class='navbar navbar-expand-lg navigation navbar-light bg-light'>
-    <%= link_to '#', class: 'navbar-brand' do %>
-      <%= image_tag 'logo.png' %>
-    <% end %>
-    <button class='navbar-toggler' data-bs-toggle='collapse' data-bs-target='#navbarSupportedContent'
-      aria-controls='navbarSupportedContent' aria-expanded='false' aria-label='Toggle navigation'>
-      <span class='navbar-toggler-icon'></span>
-    </button>
+<header class="flex justify-between bg-green h-15 font-white">
+  <%= link_to diaries_path, class: "logo" do %>
+    <%= image_tag "logo.png", class: "img-top", width: "70", height:"70" %>
+  <% end %>
 
-    <div class='collapse navbar-collapse' id='navbarSupportedContent'>
-      <ul class='navbar-nav ms-auto main-nav align-items-center'>
-        <li class='nav-item dropdown dropdown-slide'>
-          <%= link_to '掲示板', '#', class: 'nav-link dropdown-toggle', data: { bs_toggle: 'dropdown' }, aria: { haspopup: 'true', expanded: 'false' }, id: 'header-board-menu' %>
-          <div class='dropdown-menu dropdown-menu-end'>
-            <%= link_to '掲示板一覧', '#', class: 'dropdown-item' %>
-            <%= link_to '掲示板作成', '#', class: 'dropdown-item' %>
+  <button class="">
+    <span class="toggler-icon"></span>
+  </button>
+
+  <div class="collapse" id="navbarSupportedContent">
+    <ul class="ms-auto flex">
+      <li class="mr-5">
+        <%= link_to "/", class: "nav-link", id: "header-menu" do %>
+          <div class="text-4xl">
+            <i class="fa-solid fa-question"></i>
           </div>
-        </li>
-
-        <li class='nav-item'>
-          <%= link_to 'ブックマーク一覧', '#', class: 'nav-link' %>
-        </li>
-
-        <li class='nav-item dropdown dropdown-slide'>
-          <%= link_to '#', class: 'nav-link', data: { bs_toggle: 'dropdown' }, aria: { haspopup: 'true', expanded: 'false' }, id: 'header-profile' do %>
-            <%= image_tag 'sample.jpg', class: 'rounded-circle mr15', width: '40', height: '40' %>
-          <% end %>
-          <div class='dropdown-menu dropdown-menu-end'>
-            <div class='dropdown-item'>らんてっく たろう</div>
-            <div class='dropdown-divider'></div>
-            <%= link_to 'プロフィール', '#', class: 'dropdown-item' %>
-            <%= link_to 'ログアウト', '#', class: 'dropdown-item' %>
+          <div class="text-base">
+            使い方
           </div>
-        </li>
-      </ul>
-    </div>
-  </nav>
+        <% end %>
+      </li>
+
+      <li class="nav-item ml-5 mr-5">
+        <%= link_to "#", class: "nav-link", id: "header-menu" do %>
+          <div class="text-4xl">
+            <i class="fa-solid fa-mountain-sun"></i>
+          </div>
+          <div class="text-base">
+            ミッション
+          </div>
+        <% end %>
+      </li>
+    </ul>
+  </div>
 </header>

--- a/app/views/shared/_like.html.erb
+++ b/app/views/shared/_like.html.erb
@@ -1,0 +1,15 @@
+<% if current_user && current_user.own?(diary) %>
+  <div id="btn_animation", class="btn_box">
+    <i class="btnn fa-solid fa-heart text-5xl pt-2"></i>
+  </div>
+  <div id="count-<%=diary.id%>", class="text-base mx-7 pt-0">
+    <h2><%= Like.likes_count(diary.id) || 0 %></h1>
+  </div>
+<% else %>
+  <%= button_to likes_path(diary_id: diary.id), id: "btn_animation", class: "flex btn_box", method: { turbo_method: :post } do %>
+    <i class="btnn fa-solid fa-heart text-5xl pt-2"></i>
+  <% end %>
+  <div id="count-<%=diary.id%>", class="text-base mx-7 pt-0">
+    <h2><%= Like.likes_count(diary.id) || 0 %></h1>
+  </div>
+<% end %>


### PR DESCRIPTION
## 概要
* rails_turboはすでに導入済み
* views/likesにcreate.turbo_stream.erbを作成
* show.html.erbと_diary.html.erbのいいね部分をパーシャル化し、count-<%=diary.id%>を用意。
* create.turbo_stream.erbにcount-<%=diary.id%>をturbo_replaceするように記述
* いいねボタンを押すとカウントが非同期で増加することを確認

close #22 