### PR TITLE
fix:application.tailwind.cssの冒頭部分を@importから@tailwindの記述に再度書き換え

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -1,6 +1,6 @@
-@import "tailwindcss/base";
-@import "tailwindcss/components";
-@import "tailwindcss/utilities";
+@tailwind base;
+@tailwind components;
+@tailwind utilities; 
 
 .bg-green {
     background-color: #65C294;


### PR DESCRIPTION
application.tailwind.cssの冒頭部分を@importを使った記述から@tailwindを使った記述に戻した。