### PR TITLE
Mission checks

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -2,21 +2,8 @@
 @import "tailwindcss/components";
 @import "tailwindcss/utilities";
 
-.fixed_btn { 
-  position: fixed;
-  bottom: 10px;
-  right: 10px;
-  padding: 6px 40px;
-  }
-
 .bg-green {
     background-color: #65C294;
-}
-
-.nav-bar {
-    display: flex;
-    flex-direction: row;
-    justify-content: space-between;
 }
 
 .line-color {
@@ -27,10 +14,6 @@
 .line-color:hover {
     background-color: #06C755;
     border: solid #06C755;
-}
-
-.items-flex-end {
-  align-items: flex-end;
 }
 
 #btn_animation .btnn {

--- a/app/controllers/diaries_controller.rb
+++ b/app/controllers/diaries_controller.rb
@@ -13,7 +13,11 @@ class DiariesController < ApplicationController
   def create
     @diary = current_user.diaries.build(diary_params)
     if @diary.save
-      DailyMission.check_create_diary_today_mission(current_user)
+      if DailyMission.check_create_diary_today_mission(current_user)
+        @daily_missions_update = current_user.user_dailies.where(status: true)
+        flash[:daily_missions_update] = t('defaults.flash_message.daily_missions_updated', item: "#{@daily_missions_update.count}")
+        logger.debug "@daily_missions_update are #{@daily_missions_update}"
+      end
       redirect_to diaries_path, success: t('defaults.flash_message.created', item: t('activerecord.models.diary'))
     else
       flash.now[:danger] = t('defaults.flash_message.not_created', item: t('activerecord.models.diary'))

--- a/app/controllers/diaries_controller.rb
+++ b/app/controllers/diaries_controller.rb
@@ -13,6 +13,7 @@ class DiariesController < ApplicationController
   def create
     @diary = current_user.diaries.build(diary_params)
     if @diary.save
+      DailyMission.check_create_diary_today_mission(current_user)
       redirect_to diaries_path, success: t('defaults.flash_message.created', item: t('activerecord.models.diary'))
     else
       flash.now[:danger] = t('defaults.flash_message.not_created', item: t('activerecord.models.diary'))

--- a/app/controllers/missions_controller.rb
+++ b/app/controllers/missions_controller.rb
@@ -4,11 +4,13 @@ class MissionsController < ApplicationController
   def show
     case params[:type]
     when 'daily'
-      @missions = DailyMission.all
-      render partial: 'shared/daily_missions', locals: { daily_missions: @missions }
+      @missions = current_user.my_dailies
+      @mission_status = current_user.user_dailies.index_by(&:daily_mission_id)
+      render partial: 'shared/daily_missions', locals: { daily_missions: @missions, daily_status: @mission_status }
     when 'challenge'
-      @missions = ChallengeMission.all
-      render partial: 'shared/challenge_missions', locals: { challenge_missions: @missions }
+      @missions = current_user.my_challenges
+      @mission_status = current_user.user_challenges.index_by(&:challenge_mission_id)
+      render partial: 'shared/challenge_missions', locals: { challenge_missions: @missions, challenge_status: @mission_status }
     else
       render plain: 'Invalid mission type', status: :bad_request
     end

--- a/app/controllers/missions_controller.rb
+++ b/app/controllers/missions_controller.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class MissionsController < ApplicationController
+  before_action :authenticate_user!, only: %i[show]
   def show
     case params[:type]
     when 'daily'

--- a/app/controllers/omniauth_callbacks_controller.rb
+++ b/app/controllers/omniauth_callbacks_controller.rb
@@ -16,8 +16,10 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
                                                 name: @omniauth['info']['name'], password: Devise.friendly_token[0, 20])
       end
       @profile.set_values(@omniauth)
+      @profile.save!
       sign_in(:user, @profile)
       buff_process(@profile)
+      missions_process(@profile)
     end
     flash[:notice] = 'ログインしました'
     redirect_to diaries_path
@@ -28,6 +30,13 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
   end
 
   def buff_process(user)
-    Buff.find_or_create_by!(user_id: user.id)
+    Rails.logger.info "buff_process executed"
+    user.ensure_buff_exists
+  end
+
+  def missions_process(user)
+    Rails.logger.info "missions_process executed"
+    DailyMission.check_record_user_dailies(user.id)
+    ChallengeMission.check_record_user_challenges(user.id)
   end
 end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -4,6 +4,7 @@ module Users
   class SessionsController < Devise::SessionsController
     # before_action :configure_sign_in_params, only: [:create]
     after_action :buff_process, only: :create
+    after_action :missions_process, only: :create
     # GET /resource/sign_in
     # def new
     #   super
@@ -28,7 +29,15 @@ module Users
     private
 
     def buff_process
-      Buff.find_or_create_by!(user_id: current_user.id)
+      Rails.logger.info "buff_process executed"
+      current_user.ensure_buff_exists
     end
+
+    def missions_process
+      Rails.logger.info "missions_process executed"
+      DailyMission.check_record_user_dailies(user_id: current_user.id)
+      ChallengeMission.check_record_user_challenges(user_id: current_user.id)
+    end
+
   end
 end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -3,8 +3,7 @@
 module Users
   class SessionsController < Devise::SessionsController
     # before_action :configure_sign_in_params, only: [:create]
-    after_action :buff_process, only: :create
-    after_action :missions_process, only: :create
+    after_action :buff_missions_process, only: :create
     # GET /resource/sign_in
     # def new
     #   super
@@ -28,16 +27,13 @@ module Users
     # end
     private
 
-    def buff_process
+    def buff_missions_process
       Rails.logger.info "buff_process executed"
       current_user.ensure_buff_exists
-    end
 
-    def missions_process
       Rails.logger.info "missions_process executed"
-      DailyMission.check_record_user_dailies(user_id: current_user.id)
-      ChallengeMission.check_record_user_challenges(user_id: current_user.id)
+      DailyMission.check_record_user_dailies(current_user.id)
+      ChallengeMission.check_record_user_challenges(current_user.id)
     end
-
   end
 end

--- a/app/models/challenge_mission.rb
+++ b/app/models/challenge_mission.rb
@@ -1,6 +1,19 @@
 # frozen_string_literal: true
 
 class ChallengeMission < ApplicationRecord
+  has_many :user_challenges, dependent: :destroy
+
   validates :title, presence: true, length: { maximum: 255 }
   validates :description, presence: true, length: { maximum: 65_535 }
+
+  def self.check_record_user_challenges(user_id)
+    challenge_mission_ids = ChallengeMission.pluck(:id)
+    existing_challenge_mission_ids = UserChallenge.where(user_id: user_id, challenge_mission_id: challenge_mission_ids).pluck(:challenge_mission_id)
+
+    missing_challenge_mission_ids = challenge_mission_ids - existing_challenge_mission_ids
+
+    missing_challenge_mission_ids.each do |challenge_mission_id|
+      UserChallenge.create(user_id: user_id, challenge_mission_id: challenge_mission_id)
+    end
+  end
 end

--- a/app/models/daily_mission.rb
+++ b/app/models/daily_mission.rb
@@ -24,7 +24,7 @@ class DailyMission < ApplicationRecord
     today_diary = user.diaries.find_by(created_at: Date.today.beginning_of_day..Date.today.end_of_day)
     if today_diary.present?
       logger.debug "user_daily.update executed"
-      @mission_update = user_daily.update(status: true)
+      @daily_mission_update = user_daily.update(status: true)
       user.add_daily_buff(mission.buff)
     end
   end

--- a/app/models/daily_mission.rb
+++ b/app/models/daily_mission.rb
@@ -7,13 +7,25 @@ class DailyMission < ApplicationRecord
   validates :description, presence: true, length: { maximum: 65_535 }
 
   def self.check_record_user_dailies(user_id)
-    daily_mission_ids = DailyMission.pluck(:id)
+    daily_mission_ids = self.pluck(:id)
     existing_daily_mission_ids = UserDaily.where(user_id: user_id, daily_mission_id: daily_mission_ids).pluck(:daily_mission_id)
 
     missing_daily_mission_ids = daily_mission_ids - existing_daily_mission_ids
 
     missing_daily_mission_ids.each do |daily_mission_id|
       UserDaily.create(user_id: user_id, daily_mission_id: daily_mission_id)
+    end
+  end
+
+  def self.check_create_diary_today_mission(user)
+    logger.debug "check_create_diary_mission executed"
+    mission = self.find_by("title LIKE?", "%日記を投稿する%")
+    user_daily = user.user_dailies.find_by(daily_mission_id: mission.id)
+    today_diary = user.diaries.find_by(created_at: Date.today.beginning_of_day..Date.today.end_of_day)
+    if today_diary.present?
+      logger.debug "user_daily.update executed"
+      @mission_update = user_daily.update(status: true)
+      user.add_daily_buff(mission.buff)
     end
   end
 end

--- a/app/models/daily_mission.rb
+++ b/app/models/daily_mission.rb
@@ -22,9 +22,9 @@ class DailyMission < ApplicationRecord
     mission = self.find_by("title LIKE?", "%日記を投稿する%")
     user_daily = user.user_dailies.find_by(daily_mission_id: mission.id)
     today_diary = user.diaries.find_by(created_at: Date.today.beginning_of_day..Date.today.end_of_day)
-    if today_diary.present?
+    if today_diary.present? && !user_daily.status
       logger.debug "user_daily.update executed"
-      @daily_mission_update = user_daily.update(status: true)
+      user_daily.update(status: true)
       user.add_daily_buff(mission.buff)
     end
   end

--- a/app/models/daily_mission.rb
+++ b/app/models/daily_mission.rb
@@ -1,6 +1,19 @@
 # frozen_string_literal: true
 
 class DailyMission < ApplicationRecord
+  has_many :user_dailies, dependent: :destroy
+
   validates :title, presence: true, length: { maximum: 255 }
   validates :description, presence: true, length: { maximum: 65_535 }
+
+  def self.check_record_user_dailies(user_id)
+    daily_mission_ids = DailyMission.pluck(:id)
+    existing_daily_mission_ids = UserDaily.where(user_id: user_id, daily_mission_id: daily_mission_ids).pluck(:daily_mission_id)
+
+    missing_daily_mission_ids = daily_mission_ids - existing_daily_mission_ids
+
+    missing_daily_mission_ids.each do |daily_mission_id|
+      UserDaily.create(user_id: user_id, daily_mission_id: daily_mission_id)
+    end
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -12,6 +12,13 @@ class User < ApplicationRecord
   has_many :comments, dependent: :destroy
   has_many :likes, dependent: :destroy
   has_many :like_diaries, through: :likes, source: :diary
+  has_many :user_dailies, dependent: :destroy
+  has_many :user_challenges, dependent: :destroy
+  has_many :my_dailies, through: :user_dailies, source: :daily_mission
+  has_many :my_challenges, through: :user_challenges, source: :challenge_mission
+
+  after_create :create_buff
+  after_commit :ensure_buff_exists, on: :create
 
   # for line-login
   def social_profile(provider)
@@ -34,6 +41,14 @@ class User < ApplicationRecord
   def set_values_by_raw_info(raw_info)
     self.raw_info = raw_info.to_json
     save!
+  end
+
+  def create_buff
+    self.create_buff!
+  end
+
+  def ensure_buff_exists
+    self.buff || self.create_buff!
   end
 
   def own?(object)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -60,4 +60,19 @@ class User < ApplicationRecord
     like.count += diary.user.buff.sum_buff
     like.save!
   end
+
+  def add_daily_buff(target_buff)
+    logger.debug "add_daily_buff executed"
+    current_buff = self.buff
+    current_buff.daily_buff += target_buff
+    current_buff.save!
+    self.sum_buff
+  end
+
+  def sum_buff
+    logger.debug "add_daily_buff executed"
+    current_buff = self.buff
+    current_buff.sum_buff += current_buff.daily_buff + current_buff.challenge_buff
+    current_buff.save!
+  end
 end

--- a/app/views/diaries/show.html.erb
+++ b/app/views/diaries/show.html.erb
@@ -3,7 +3,7 @@
   <div class="user-name text-center text-black font-bold text-2xl">
     <%= @diary.user.name %>
   </div>
-  <div class="flex items-flex-end">
+  <div class="flex items-end">
     <%= render partial: "show_diary", locals: {diary: @diary} %>
   </div>
   <div id="like-<%=@diary.id%>" class="flex pl-20 pt-0">

--- a/app/views/shared/_challenge_missions.html.erb
+++ b/app/views/shared/_challenge_missions.html.erb
@@ -1,7 +1,24 @@
-<!-- app/views/shared/_challenge_missions.html.erb -->
-<% challenge_missions.each do |mission| %>
-  <div>
-    <h4><%= mission.title %></h4>
-    <p><%= mission.description %></p>
-  </div>
-<% end %>
+<table>
+  <thead>
+    <tr>
+      <th>ミッションID</th>
+      <th>タイトル</th>
+      <th>ステータス</th>
+    </tr>
+  </thead>
+  <tbody>
+    <% challenge_missions.each do |mission| %>
+      <tr>
+        <td><%= mission.id %></td>
+        <td><%= mission.title %></td>
+        <td>
+          <% if challenge_status[mission.id]&.status %>
+            達成済
+          <% else %>
+            未達成
+          <% end %>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/shared/_daily_missions.html.erb
+++ b/app/views/shared/_daily_missions.html.erb
@@ -1,7 +1,24 @@
-<!-- app/views/shared/_daily_missions.html.erb -->
-<% daily_missions.each do |mission| %>
-  <div>
-    <h4><%= mission.title %></h4>
-    <p><%= mission.description %></p>
-  </div>
-<% end %>
+<table>
+  <thead>
+    <tr>
+      <th>ミッションID</th>
+      <th>タイトル</th>
+      <th>ステータス</th>
+    </tr>
+  </thead>
+  <tbody>
+    <% daily_missions.each do |mission| %>
+      <tr>
+        <td><%= mission.id %></td>
+        <td><%= mission.title %></td>
+        <td>
+          <% if daily_status[mission.id]&.status %>
+            達成済
+          <% else %>
+            未達成
+          <% end %>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -18,9 +18,9 @@
 
     <li class="mr-5">
       <div class="dropdown dropdown-end">
-        <% if @daily_mission_update.present? %>
+        <% if flash[:daily_missions_update].present? %>
           <div class="indicator">
-            <span class="indicator-item badge badge-secondary">99+</span>
+            <span class="indicator-item indicator-bottom indicator-start badge badge-secondary">check!</span>
             <button class="" tabindex="0">
               <i class="fa-solid fa-mountain-sun text-4xl"></i>
               <div class="text-base">

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -18,12 +18,24 @@
 
     <li class="mr-5">
       <div class="dropdown dropdown-end">
-        <button class="" tabindex="0">
-          <i class="fa-solid fa-mountain-sun text-4xl"></i>
-          <div class="text-base">
-            ミッション
+        <% if @daily_mission_update.present? %>
+          <div class="indicator">
+            <span class="indicator-item badge badge-secondary">99+</span>
+            <button class="" tabindex="0">
+              <i class="fa-solid fa-mountain-sun text-4xl"></i>
+              <div class="text-base">
+                ミッション
+              </div>
+            </button>
           </div>
-        </button>
+        <% else %>
+          <button class="" tabindex="0">
+            <i class="fa-solid fa-mountain-sun text-4xl"></i>
+            <div class="text-base">
+              ミッション
+            </div>
+          </button>
+        <% end %>
         <ul tabindex="0" class="dropdown-content menu bg-base-100 rounded-box z-[1] w-52 p-2 shadow">
           <li>
             <button class="" onclick="my_modal_1.showModal(); loadMissions('daily', 'mission-list-daily')">

--- a/app/views/shared/_nav.html.erb
+++ b/app/views/shared/_nav.html.erb
@@ -1,5 +1,5 @@
 <div id="navbarSupportedContent">
-  <ul class="flex nav-bar items-center ml-8">
+  <ul class="flex items-center ml-8">
     <li class="nav-item w-full">
       <%= link_to diaries_path, class: "nav-link", id: "home" do %>
         <div class="text-4xl">

--- a/config/locales/view.ja.yml
+++ b/config/locales/view.ja.yml
@@ -9,6 +9,7 @@ ja:
       not_updated: "%{item}を更新出来ませんでした・・・"
       deleted: "%{item}を削除しました"
       require_login: ログインしてください
+      daily_missions_updated: "%{item}個のデイリーミッションを達成しました！"
   helpers:
     submit:
       create: 登録


### PR DESCRIPTION
## 概要
* ユーザーログイン時にユーザーIDと各デイリー、各チャレンジの中間テーブルが作成されるようapp/controllers/omniauth_callbacks_controller.rbにmission_processを追加
* ミッションページで、各ミッションがユーザーは達成済か未達成か表示される機能を追加
* 日記作成時に、デイリーミッションの一つが達成済みになり、sum_buffが増加する機能を追加
* 他のユーザーが、sum_buffが増加したユーザーの日記をいいねすると、増加した分いいねも増えることを確認
* デイリーミッション達成時にフラッシュメッセージが表示され、ミッションボタンにインジケータが追加される機能を追加
* テストユーザー用のsessions_contoroller.rbにもuser_dailiesレコードを追加する処理を追加

## 実施内容
* daily_mission.rbにself.check_create_diary_today_missionクラスメソッドを追加
* user.rbにadd_daily_buffとsum_buffインスタンスメソッドを追加し、daily_mission.rbのクラスメソッドでステータスを更新した場合はそれらのインスタンスメソッドによってbuffが更新される処理を実装
* 現在は日記作成のデイリーミッションのみチェックする実装だが、今後の作業でデイリーミッションが増える場合を想定し、全てのデイリーミッションをチェックする記述に修正する。
* インジケータはミッションボタンの上に表示されているが、次のissueで下に表示されるよう修正する。
* ミッションページの見た目は今後のissueで整える

## ミッションページの達成/未達成表示のスクリーンショット
<img width="690" alt="image" src="https://github.com/user-attachments/assets/70aacde2-9bad-4506-b134-11188ead7808">


## フラッシュメッセージ、インジケータのスクリーンショット
<img width="1468" alt="image" src="https://github.com/user-attachments/assets/2961a4d9-361a-40d8-9908-9abb0df75307">
