### PR TITLE
Challenge mission check

### DIFF
--- a/app/controllers/diaries_controller.rb
+++ b/app/controllers/diaries_controller.rb
@@ -14,7 +14,7 @@ class DiariesController < ApplicationController
     @diary = current_user.diaries.build(diary_params)
     if @diary.save
       result = DailyMission.update_mission(user: current_user, mission_title: "日記を投稿する")
-      if result[:success]
+      if result[success: true]
         flash[:daily_missions_update] = t('defaults.flash_message.daily_missions_updated', item: result[:message])        
       end
       redirect_to diaries_path, success: t('defaults.flash_message.created', item: t('activerecord.models.diary'))

--- a/app/controllers/diaries_controller.rb
+++ b/app/controllers/diaries_controller.rb
@@ -13,10 +13,9 @@ class DiariesController < ApplicationController
   def create
     @diary = current_user.diaries.build(diary_params)
     if @diary.save
-      if DailyMission.check_create_diary_today_mission(current_user)
-        @daily_missions_update = current_user.user_dailies.where(status: true)
-        flash[:daily_missions_update] = t('defaults.flash_message.daily_missions_updated', item: "#{@daily_missions_update.count}")
-        logger.debug "@daily_missions_update are #{@daily_missions_update}"
+      result = DailyMission.update_mission(user: current_user, mission_title: "日記を投稿する")
+      if result[:success]
+        flash[:daily_missions_update] = t('defaults.flash_message.daily_missions_updated', item: result[:message])        
       end
       redirect_to diaries_path, success: t('defaults.flash_message.created', item: t('activerecord.models.diary'))
     else

--- a/app/controllers/likes_controller.rb
+++ b/app/controllers/likes_controller.rb
@@ -9,6 +9,7 @@ class LikesController < ApplicationController
     current_user.like(@diary)
     result = current_user.liked_diary_count
     if result[:success]
+      logger.debug "like_count update"
       flash[:challenge_missions_update] = t('defaults.flash_message.challenge_missions_updated', item: result[:message])
     end
   end
@@ -22,7 +23,7 @@ class LikesController < ApplicationController
         current_user.like(diary)
       end
       result = current_user.liked_diary_count
-      if result[:success]
+      if result
         flash[:challenge_missions_update] = t('defaults.flash_message.challenge_missions_updated', item: result[:message])
       end
       redirect_to diaries_path, success: t('likes.everything_success')

--- a/app/controllers/likes_controller.rb
+++ b/app/controllers/likes_controller.rb
@@ -7,6 +7,10 @@ class LikesController < ApplicationController
   def create
     @diary = Diary.find_by(id: params[:diary_id])
     current_user.like(@diary)
+    result = current_user.liked_diary_count
+    if result[:success]
+      flash[:challenge_missions_update] = t('defaults.flash_message.challenge_missions_updated', item: result[:message])
+    end
   end
 
   def everything
@@ -16,6 +20,10 @@ class LikesController < ApplicationController
       @today_diaries.each do |diary|
         puts "diaryの値は#{diary}"
         current_user.like(diary)
+      end
+      result = current_user.liked_diary_count
+      if result[:success]
+        flash[:challenge_missions_update] = t('defaults.flash_message.challenge_missions_updated', item: result[:message])
       end
       redirect_to diaries_path, success: t('likes.everything_success')
     else

--- a/app/controllers/omniauth_callbacks_controller.rb
+++ b/app/controllers/omniauth_callbacks_controller.rb
@@ -34,6 +34,11 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
     user.ensure_buff_exists
   end
 
+  def reward_process(user)
+    Rails.logger.info "reward_process executed"
+    user.ensure_reward_exists
+  end
+
   def missions_process(user)
     Rails.logger.info "missions_process executed"
     DailyMission.check_record_user_dailies(user.id)

--- a/app/controllers/omniauth_callbacks_controller.rb
+++ b/app/controllers/omniauth_callbacks_controller.rb
@@ -19,6 +19,7 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
       @profile.save!
       sign_in(:user, @profile)
       buff_process(@profile)
+      reward_process(@profile)
       missions_process(@profile)
     end
     flash[:notice] = 'ログインしました'

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -32,7 +32,7 @@ module Users
       current_user.ensure_buff_exists
 
       Rails.logger.info "reward_process executed"
-      user.ensure_reward_exists
+      current_user.ensure_reward_exists
 
       Rails.logger.info "missions_process executed"
       DailyMission.check_record_user_dailies(current_user.id)

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -3,7 +3,7 @@
 module Users
   class SessionsController < Devise::SessionsController
     # before_action :configure_sign_in_params, only: [:create]
-    after_action :buff_missions_process, only: :create
+    after_action :buff_reward_missions_process, only: :create
     # GET /resource/sign_in
     # def new
     #   super
@@ -27,9 +27,12 @@ module Users
     # end
     private
 
-    def buff_missions_process
+    def buff_reward_missions_process
       Rails.logger.info "buff_process executed"
       current_user.ensure_buff_exists
+
+      Rails.logger.info "reward_process executed"
+      user.ensure_reward_exists
 
       Rails.logger.info "missions_process executed"
       DailyMission.check_record_user_dailies(current_user.id)

--- a/app/models/challenge_mission.rb
+++ b/app/models/challenge_mission.rb
@@ -19,23 +19,26 @@ class ChallengeMission < ApplicationRecord
 
   def self.update_mission(user:, mission_title:)
     mission = self.find_by("title LIKE ?", "%#{mission_title}%")
-    logger.debug "mission #{mission}"
-    return { success: false, message: 'Mission not found' } unless mission
+    logger.debug "message::::mission #{mission}"
+    return false unless mission
 
     user_challenge = user.user_challenges.find_by(challenge_mission_id: mission.id)
-    logger.debug "user_daily #{user_challenge.inspect}"
+    logger.debug "message::::user_daily #{user_challenge.inspect}"
     if user_challenge.present? && !user_challenge.status
-      logger.debug "user_daily.update executed"
+      logger.debug "message::::user_daily.update executed"
       user_challenge.update(status: true)
       result = user.add_buff(challenge: mission.buff, mission: mission)
-      if result[:success]
-        { success: true, message: mission.title }
+      logger.debug "message::::add_buff result #{result}"
+      if result
+        logger.debug "message::::add_buff success"
+        return true
       else
-        { success: false, message: 'update failed' }
+        logger.debug "error::::add_buff failed"
+        return false
       end
     else
-      logger.debug "mission not found or user_challenge_status is already true"
-      { success: false, message: 'Mission not found or already completed' }
+      logger.debug "message::::mission not found or user_challenge_status is already true"
+      return false
     end
   end
 end

--- a/app/models/challenge_mission.rb
+++ b/app/models/challenge_mission.rb
@@ -24,5 +24,6 @@ class ChallengeMission < ApplicationRecord
       logger.debug "user_challenge.update executed"
       user_challenge.update(status: true)
       user.add_challenge_buff(mission.buff)
+    end
   end
 end

--- a/app/models/challenge_mission.rb
+++ b/app/models/challenge_mission.rb
@@ -16,4 +16,13 @@ class ChallengeMission < ApplicationRecord
       UserChallenge.create(user_id: user_id, challenge_mission_id: challenge_mission_id)
     end
   end
+
+  def self.check_count_like_record(user)
+    mission = self.find_by("title LIKE?", "%10個の日記にいいね%")
+    user_challenge = user.user_challenges.find_by(challenge_mission_id: mission.id)
+    if !user_challenge.status
+      logger.debug "user_challenge.update executed"
+      user_challenge.update(status: true)
+      user.add_challenge_buff(mission.buff)
+  end
 end

--- a/app/models/daily_mission.rb
+++ b/app/models/daily_mission.rb
@@ -17,15 +17,21 @@ class DailyMission < ApplicationRecord
     end
   end
 
-  def self.check_create_diary_today_mission(user)
-    logger.debug "check_create_diary_mission executed"
-    mission = self.find_by("title LIKE?", "%日記を投稿する%")
+  def self.update_mission(user:, mission_title:)
+    mission = self.find_by("title LIKE ?", "%#{mission_title}%")
+    logger.debug "mission #{mission}"
+    return { success: false, message: 'Mission not found' } unless mission
+
     user_daily = user.user_dailies.find_by(daily_mission_id: mission.id)
-    today_diary = user.diaries.find_by(created_at: Date.today.beginning_of_day..Date.today.end_of_day)
-    if today_diary.present? && !user_daily.status
+    logger.debug "user_daily #{user_daily.inspect}"
+    if user_daily.present? && !user_daily.status
       logger.debug "user_daily.update executed"
       user_daily.update(status: true)
-      user.add_daily_buff(mission.buff)
+      user.add_daily_buff(daily: mission.buff)
+      { success: true, message: mission.title }
+    else
+      logger.debug "mission not found or user_challenge_status is already true"
+      { success: false, message: 'Mission not found or already completed' }
     end
   end
 end

--- a/app/models/reward.rb
+++ b/app/models/reward.rb
@@ -1,0 +1,3 @@
+class Reward < ApplicationRecord
+  belongs_to :user
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -61,6 +61,10 @@ class User < ApplicationRecord
     like.save!
   end
 
+  def liked_diary_count
+    self.like_diary.where(created_at: Date.today.beginning_of_day..Date.today.end_of_day)
+  end
+
   def add_daily_buff(target_buff)
     logger.debug "add_daily_buff executed"
     current_buff = self.buff

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -19,7 +19,7 @@ class User < ApplicationRecord
   has_many :my_challenges, through: :user_challenges, source: :challenge_mission
 
   after_create :create_buff, :create_reward
-  after_commit :ensure_buff_exists, :ensure_reward_exists, :create
+  after_commit :ensure_buff_exists, :ensure_reward_exists,on: :create
 
   # for line-login
   def social_profile(provider)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -62,7 +62,10 @@ class User < ApplicationRecord
   end
 
   def liked_diary_count
-    self.like_diary.where(created_at: Date.today.beginning_of_day..Date.today.end_of_day)
+    counts = self.likes.count
+    if counts > 100
+      ChallengeMission
+    end
   end
 
   def add_daily_buff(target_buff)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -74,54 +74,59 @@ class User < ApplicationRecord
     counts = self.likes.count
     if counts > 10
       result = ChallengeMission.update_mission(user: self, mission_title: "10個の日記にいいね")
-      if result[:success]
-      {success: true, message: result[:message]}
+      if result
+        { success: true, message: "10個の日記にいいね" }
+      else
+        logger.debug "message::::like_count not update"
+        { success: false }
+      end
+    else
+      logger.debug "message::::like_count not update"
+      { success: false }
     end
   end
 
   def add_buff(daily: 0, challenge: 0, mission: nil)
-    logger.debug "add_buff executed"
+    logger.debug "message::::add_buff executed"
     current_buff = self.buff
-    return { success: false} unless current_buff
     if daily > 0
       current_buff.daily_buff += daily
-      logger.debug "daily_buff: #{current_buff.daily_buff}"
+      logger.debug "message::::daily_buff: #{current_buff.daily_buff}"
       current_buff.save!
-      self.sum_buff += current_buff.daily_buff
+      current_buff.sum_buff += current_buff.daily_buff
       current_buff.save!
-      {success: true, message: "buff updated"}
+      return true
     elsif challenge > 0
       current_buff.challenge_buff += challenge
-      logger.debug "challenge_buff: #{current_buff.challenge_buff}"    
+      logger.debug "message::::challenge_buff: #{current_buff.challenge_buff}"    
       current_buff.save!
-      self.sum_buff += current_buff.challenge_buff
+      current_buff.sum_buff += current_buff.challenge_buff
       current_buff.save!
       result = self.update_reward(mission)
-      if result[:success]
-        {success: true, message: "buff & reward updated"}
-      else
-        {success: true, message: "buff updated"}
-      end
+      logger.debug "message::::update_reward result #{result}"
+      return true
     else
-      logger.debug "cannot add buff"
-      {success: false}
+      logger.debug "error::::cannot add buff"
+      return false
     end
     
   end
 
   def update_reward(mission)
+    logger.debug "message::::update_reward executed"
+    logger.debug "message::::mission is #{mission.inspect}"
     reward = self.reward
     if mission.like_css.present?
       reward.like_css += mission.like_css
-      logger.debug "like_css update"
+      logger.debug "message::::like_css update"
     end
     if mission.diary_css.present?
       reward.diary_css += mission.diary_css
-      logger.debug "diary_css update"
+      logger.debug "message::::diary_css update"
     end
     if mission.theme_css.present?
       reward.theme_css += mission.theme_css
-      logger.debug "theme_css update"
+      logger.debug "message::::theme_css update"
     end
     
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,6 +9,7 @@ class User < ApplicationRecord
 
   has_many :diaries, dependent: :destroy
   has_one :buff, dependent: :destroy
+  has_one :reward, dependent: :destroy
   has_many :comments, dependent: :destroy
   has_many :likes, dependent: :destroy
   has_many :like_diaries, through: :likes, source: :diary
@@ -17,8 +18,8 @@ class User < ApplicationRecord
   has_many :my_dailies, through: :user_dailies, source: :daily_mission
   has_many :my_challenges, through: :user_challenges, source: :challenge_mission
 
-  after_create :create_buff
-  after_commit :ensure_buff_exists, on: :create
+  after_create :create_buff, :create_reward
+  after_commit :ensure_buff_exists, :ensure_reward_exists, :create
 
   # for line-login
   def social_profile(provider)
@@ -49,6 +50,14 @@ class User < ApplicationRecord
 
   def ensure_buff_exists
     self.buff || self.create_buff!
+  end
+
+  def create_reward
+    self.create_reward!
+  end
+
+  def ensure_reward_exists
+    self.reward || self.create_reward!
   end
 
   def own?(object)

--- a/app/views/memories/_memory_diary.html.erb
+++ b/app/views/memories/_memory_diary.html.erb
@@ -1,5 +1,5 @@
-<tr class="border-green-50">
-  <td class="border-green-50">
+<tr>
+  <td>
     <div id="diary-id-<%= memory_diary.id %>">
       <div class="card-body">
         <%= link_to diary_path(memory_diary.id), class: "flex justify-center items-center text-xl" do %>

--- a/app/views/memories/index.html.erb
+++ b/app/views/memories/index.html.erb
@@ -11,7 +11,7 @@
       </div>
     <% end %>
   <% end %>
-  <table class="border-green-5000">
+  <table class="flex items-center justify-center">
     <tbody>
       <%= render partial: "memory_diary", collection: @diaries %>
     </tbody>

--- a/app/views/shared/_challenge_missions.html.erb
+++ b/app/views/shared/_challenge_missions.html.erb
@@ -1,9 +1,15 @@
 <table>
   <thead>
     <tr>
-      <th>ミッションID</th>
-      <th>タイトル</th>
-      <th>ステータス</th>
+      <th>
+        <%= t('missions.id') %>
+      </th>
+      <th>
+        <%= t('missions.content') %>
+      </th>
+      <th>
+        <%= t('missions.status') %>
+      </th>
     </tr>
   </thead>
   <tbody>
@@ -13,9 +19,9 @@
         <td><%= mission.title %></td>
         <td>
           <% if challenge_status[mission.id]&.status %>
-            達成済
+            <%= t('missions.true') %>
           <% else %>
-            未達成
+            <%= t('missions.false') %>
           <% end %>
         </td>
       </tr>

--- a/app/views/shared/_daily_missions.html.erb
+++ b/app/views/shared/_daily_missions.html.erb
@@ -1,9 +1,15 @@
 <table>
   <thead>
     <tr>
-      <th>ミッションID</th>
-      <th>タイトル</th>
-      <th>ステータス</th>
+      <th>
+        <%= t('missions.id') %>
+      </th>
+      <th>
+        <%= t('missions.content') %>
+      </th>
+      <th>
+        <%= t('missions.status') %>
+      </th>
     </tr>
   </thead>
   <tbody>
@@ -13,9 +19,9 @@
         <td><%= mission.title %></td>
         <td>
           <% if daily_status[mission.id]&.status %>
-            達成済
+            <%= t('missions.true') %>
           <% else %>
-            未達成
+            <%= t('missions.false') %>
           <% end %>
         </td>
       </tr>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -20,7 +20,7 @@
       <div class="dropdown dropdown-end">
         <% if flash[:daily_missions_update].present? %>
           <div class="indicator">
-            <span class="indicator-item indicator-bottom indicator-start badge badge-secondary">check!</span>
+            <span class="indicator-item indicator-bottom indicator-center badge badge-secondary">check!</span>
             <button class="" tabindex="0">
               <i class="fa-solid fa-mountain-sun text-4xl"></i>
               <div class="text-base">

--- a/config/locales/view.ja.yml
+++ b/config/locales/view.ja.yml
@@ -51,6 +51,12 @@ ja:
     previous: "<<"
     next: ">>"
     week: 週間
+  missions:
+    id: ミッションID
+    content: 内容
+    status: ステータス
+    true: 達成
+    false: 未達成
   
   title:
     home: ホーム

--- a/config/locales/view.ja.yml
+++ b/config/locales/view.ja.yml
@@ -9,7 +9,8 @@ ja:
       not_updated: "%{item}を更新出来ませんでした・・・"
       deleted: "%{item}を削除しました"
       require_login: ログインしてください
-      daily_missions_updated: "%{item}個のデイリーミッションを達成しました！"
+      daily_missions_updated: "デイリーミッション「%{item}」を達成しました！"
+      challenge_missions_updated: "チャレンジミッション「%{item}」を達成しました！"
   helpers:
     submit:
       create: 登録

--- a/db/migrate/20240723142638_create_rewards.rb
+++ b/db/migrate/20240723142638_create_rewards.rb
@@ -1,0 +1,12 @@
+class CreateRewards < ActiveRecord::Migration[7.1]
+  def change
+    create_table :rewards do |t|
+      t.references :user, foreign_key: true
+      t.integer :like_css, default: 0, null: false
+      t.integer :diary_css, default: 0, null: false
+      t.integer :theme_css, default: 0, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_07_18_133414) do
+ActiveRecord::Schema[7.1].define(version: 2024_07_23_142638) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -74,6 +74,16 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_18_133414) do
     t.index ["user_id"], name: "index_likes_on_user_id"
   end
 
+  create_table "rewards", force: :cascade do |t|
+    t.bigint "user_id"
+    t.integer "like_css", default: 0, null: false
+    t.integer "diary_css", default: 0, null: false
+    t.integer "theme_css", default: 0, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_rewards_on_user_id"
+  end
+
   create_table "user_challenges", force: :cascade do |t|
     t.boolean "status", default: false
     t.bigint "user_id"
@@ -115,6 +125,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_18_133414) do
   add_foreign_key "diaries", "users"
   add_foreign_key "likes", "diaries"
   add_foreign_key "likes", "users"
+  add_foreign_key "rewards", "users"
   add_foreign_key "user_challenges", "challenge_missions"
   add_foreign_key "user_challenges", "users"
   add_foreign_key "user_dailies", "daily_missions"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -10,18 +10,18 @@
 #     MovieGenre.find_or_create_by!(name: genre_name)
 #   end
 
-# 3.times do
-#   user = User.create!(name: Faker::Name.name,
-#                       email: Faker::Internet.unique.email,
-#                       password: 'password',
-#                       password_confirmation: 'password')
-#   puts "\"#{user.name}\" has created!"
-# end
+5.times do
+  user = User.create!(name: Faker::Name.name,
+                      email: Faker::Internet.unique.email,
+                      password: 'password',
+                      password_confirmation: 'password')
+  puts "\"#{user.name}\" has created!"
+end
 
 user_ids = User.ids
 
-4.times do |index|
-  user = User.find(user_ids.sample)
-  diary = user.diaries.create!(title: "今日は連勤#{index}日目だった", body: "まだまだ#{index}日ぐらい頑張れそう！", diary_date: Date.today)
-  puts "\"#{diary.title}\" has created!"
-end
+# 4.times do |index|
+#   user = User.find(user_ids.sample)
+#   diary = user.diaries.create!(title: "今日は連勤#{index}日目だった", body: "まだまだ#{index}日ぐらい頑張れそう！", diary_date: Date.today)
+#   puts "\"#{diary.title}\" has created!"
+# end

--- a/test/fixtures/rewards.yml
+++ b/test/fixtures/rewards.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the "{}" from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/reward_test.rb
+++ b/test/models/reward_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class RewardTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## 概要
* ミッションの処理およびステータスの更新を一個一個書く予定にしていたが、汎用性を高めたクラスメソッドに修正
* 10個の日記にいいねする。というチャレンジミッションを達成しているか確認し、user_challengeモデルの街頭レコードのstatusをtrueに更新する処理を追加
* チャレンジミッション達成時にrewardモデルのレコードも更新される処理を追加
* チャレンジミッションページを開くと、達成済みのチャレンジには達成と表示されることを確認

## 実施内容
* デイリーかチャレンジ達成時のバフ更新処理をuser.rbのadd_buffにまとめて定義
* チャレンジ達成時のユーザーのrewardレコードを更新するupdate_rewardメソッドを追加
* challenge_mission.rbにuser_challengeのstatus更新処理をself.update_missionに追加
* daily_mission.rbにuser_dailyのstatus更新処理をself.update_missionに追加
* 10個の日記にいいねするチャレンジミッションを確認するためのインスタンスメソッドliked_diary_countを追加

