### PR TITLE
fix:本番環境ではminimagicのincludesエラーが発生するためminimagicをコメントアウト

### DIFF
--- a/app/uploaders/diary_image_uploader.rb
+++ b/app/uploaders/diary_image_uploader.rb
@@ -15,8 +15,8 @@ class DiaryImageUploader < CarrierWave::Uploader::Base
     "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
   end
 
-  include CarrierWave::MiniMagick
-  process resize_to_limit: [500, 500]
+  # include CarrierWave::MiniMagick
+  # process resize_to_limit: [500, 500]
 
   def extension_allowlist
     %w(jpg jpeg gif png)

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -5,9 +5,9 @@ CarrierWave.configure do |config|
       aws_secret_access_key: ENV["AWS_SECRET_ACCESS_KEY"],
       region: 'ap-northeast-1'
     }
-  
+    config.cache_dir = "#{Rails.root}/tmp/uploads"
     config.fog_directory  = ENV["DIRECTORY_NAME"]
-    config.cache_storage = :fog
+    config.storage = :fog
     config.fog_public = false
     config.fog_attributes = { cache_control: "public, max-age=#{365.days.to_i}" } # optional, defaults to {}
   end


### PR DESCRIPTION
## 概要
本番環境で画像をアップロードすると、エラーが発生する。
ログを見ると、
```
MiniMagick::Error (You must have ImageMagick or GraphicsMagick installed):
```
というエラーが発生しているため、一度diary_image_uploader.rbのminimagic部分をコメントアウトして解決するか確認する。