### PR TITLE
update: LINEログイン時にプロフィール画像も取得するように修正

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -42,8 +42,8 @@
 
 .alert-alert {
   color: white;
-  background-color: #06C755;
-  border: solid #06C755;
+  background-color: #ff6347;
+  border: solid #ff6347;
 }
 
 #btn_animation .btnn {

--- a/app/controllers/omniauth_callbacks_controller.rb
+++ b/app/controllers/omniauth_callbacks_controller.rb
@@ -13,7 +13,7 @@ class OmniauthCallbacksController < Devise::OmniauthCallbacksController
       if @profile.email.blank?
         email = @omniauth['info']['email'] || "#{@omniauth['uid']}-#{@omniauth['provider']}@example.com"
         @profile = current_user || User.create!(provider: @omniauth['provider'], uid: @omniauth['uid'], email:,
-                                                name: @omniauth['info']['name'], password: Devise.friendly_token[0, 20])
+                                                name: @omniauth['info']['name'], image: @omniauth['info']['image'], password: Devise.friendly_token[0, 20])
       end
       @profile.set_values(@omniauth)
       @profile.save!

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -36,10 +36,12 @@ class User < ApplicationRecord
     credentials['secret']
     credentials.to_json
     info['name']
+    info['image']
     # self.set_values_by_raw_info(omniauth['extra']['raw_info'])
   end
 
   def set_values_by_raw_info(raw_info)
+    puts "pppppppppppppppp#{raw_info.to_json}"
     self.raw_info = raw_info.to_json
     save!
   end

--- a/app/views/diaries/_diary.html.erb
+++ b/app/views/diaries/_diary.html.erb
@@ -1,7 +1,11 @@
 <div id="diary-id-<%= diary.id %>" class="card flex flex-row my-9">
   <div class="avatar pt-1">
     <div class="w-20 h-20 rounded-full">
-      <%= image_tag "https://img.daisyui.com/images/stock/photo-1534528741775-53994a69daeb.jpg", alt: "#{diary.user.name}のアバター", onerror: "this.onerror=null; this.src='/assets/avatar.png'" %>
+      <% if diary.user.image.present? %>
+        <%= image_tag diary.user.image %>
+      <% else %>
+        <%= image_tag "https://img.daisyui.com/images/stock/photo-1534528741775-53994a69daeb.jpg", alt: "#{diary.user.name}のアバター", onerror: "this.onerror=null; this.src='/assets/avatar.png'" %>
+      <% end %>
     </div>
   </div>
   <div class="card-body pt-2">

--- a/db/migrate/20240811103522_add_column_to_user.rb
+++ b/db/migrate/20240811103522_add_column_to_user.rb
@@ -1,0 +1,5 @@
+class AddColumnToUser < ActiveRecord::Migration[7.1]
+  def change
+    add_column :users, :image, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_08_10_083729) do
+ActiveRecord::Schema[7.1].define(version: 2024_08_11_103522) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -116,6 +116,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_10_083729) do
     t.string "uid"
     t.string "name"
     t.boolean "remind", default: false
+    t.string "image"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end

--- a/lib/tasks/line_bot.rake
+++ b/lib/tasks/line_bot.rake
@@ -11,7 +11,7 @@ namespace :line_bot do
     end
     message = {
       type: 'text',
-      text: 'こんばんは！今日はどんな日でしたか？些細なことでも構いませんので日記に投稿してみましょう！'
+      text: 'こんばんは！今日はどんな日でしたか？些細なことでも構いませんので日記に投稿してみましょう！https://praise-diary.onrender.com'
     }
     LineBotClient.new.client.multicast(to_users, message)
   end


### PR DESCRIPTION
## 概要
* LINEログイン時にプロフィール画像も取得するように修正
* LINEアカウントのプロフィール画像がアプリ上でも表示されることを確認

## 実施内容
* userモデルにimageカラムを追加
* omniauth-lineでlineから取得しているレスポンスにはinfoキーの中にnameだけでなくimageも取得している。
* そのため、omniauth_callbackコントローラーがuserモデルから呼び出すメソッドのbasic_actionで、imageも取得してusersテーブルのレコードに登録するよう追記

def basic_action
    @omniauth = request.env['omniauth.auth']
    if @omniauth.present?
      @profile = User.find_or_initialize_by(provider: @omniauth['provider'], uid: @omniauth['uid'])
      if @profile.email.blank?
        email = @omniauth['info']['email'] || "#{@omniauth['uid']}-#{@omniauth['provider']}@example.com"
        @profile = current_user || User.create!(provider: @omniauth['provider'], uid: @omniauth['uid'], email:,
                                                name: @omniauth['info']['name'], image: @omniauth['info']['image'], password: Devise.friendly_token[0, 20])
      end

<img width="1285" alt="image" src="https://github.com/user-attachments/assets/86fceaea-c649-4b97-8089-996c38eb39cc">
