### PR TITLE
like_cssに関連する処理追加

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -54,7 +54,6 @@
   display: block;
   text-decoration: none;
   background-color: none;
-  color: #008000;
   animation: btn_animation 1.5s infinite;
 }
 

--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -32,7 +32,7 @@
   border: solid greenyellow;
 }
 
-.alert-daily-missions-update {
+.alert-daily_missions_update {
   color: black;
   background-color: greenyellow;
   border: solid greenyellow;
@@ -50,10 +50,10 @@
   border: solid #ff6347;
 }
 
-.challenge-missions-update {
+.alert-challenge_missions_update {
   color: black;
-  background-color: greenyellow;
-  border: solid greenyellow;
+  background-color: mediumturquoise;
+  border: solid mediumturquoise;
 }
 
 #btn_animation .btnn {

--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -32,7 +32,7 @@
   border: solid greenyellow;
 }
 
-.alert-daily_missions_update {
+.alert-daily-missions-update {
   color: black;
   background-color: greenyellow;
   border: solid greenyellow;
@@ -48,6 +48,12 @@
   color: white;
   background-color: #ff6347;
   border: solid #ff6347;
+}
+
+.challenge-missions-update {
+  color: black;
+  background-color: greenyellow;
+  border: solid greenyellow;
 }
 
 #btn_animation .btnn {

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -6,8 +6,12 @@ class CommentsController < ApplicationController
   def create
     comment = current_user.comments.build(comment_params)
     if comment.save
-      redirect_to diary_path(comment.diary),
-                  success: t('defaults.flash_message.created', item: t('activerecord.models.comment'))
+      result = DailyMission.update_mission(user: current_user, mission_title: 'コメントを投稿する')
+      if result[:success]
+        flash[:daily_missions_update] =
+          t('defaults.flash_message.daily_missions_updated', item: result[:message])
+      end
+      redirect_to diary_path(comment.diary), success: t('defaults.flash_message.created', item: t('activerecord.models.comment'))
     else
       render diary_path(comment.diary), status: :unprocessable_entity
     end

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -8,7 +8,7 @@ class CommentsController < ApplicationController
     if comment.save
       result = DailyMission.update_mission(user: current_user, mission_title: 'コメントを投稿する')
       if result[:success]
-        flash[:daily_missions_update] =
+        flash[:daily-missions-update] =
           t('defaults.flash_message.daily_missions_updated', item: result[:message])
       end
       redirect_to diary_path(comment.diary), success: t('defaults.flash_message.created', item: t('activerecord.models.comment'))

--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -7,7 +7,7 @@ class CommentsController < ApplicationController
     comment = current_user.comments.build(comment_params)
     if comment.save
       result = DailyMission.update_mission(user: current_user, mission_title: 'コメントを投稿する')
-      if result[:success]
+      if result[:process]
         flash[:daily-missions-update] =
           t('defaults.flash_message.daily_missions_updated', item: result[:message])
       end

--- a/app/controllers/diaries_controller.rb
+++ b/app/controllers/diaries_controller.rb
@@ -16,8 +16,8 @@ class DiariesController < ApplicationController
     logger.debug "message::::current_user.reward result #{result}"
     if @diary.save
       result = DailyMission.update_mission(user: current_user, mission_title: '日記を投稿する')
-      if result[:success]
-        flash[:daily-missions-update] =
+      if result[:process]
+        flash[:daily_missions_update] =
           t('defaults.flash_message.daily_missions_updated', item: result[:message])
       end
       redirect_to diaries_path, success: t('defaults.flash_message.created', item: t('activerecord.models.diary'))

--- a/app/controllers/diaries_controller.rb
+++ b/app/controllers/diaries_controller.rb
@@ -17,7 +17,7 @@ class DiariesController < ApplicationController
     if @diary.save
       result = DailyMission.update_mission(user: current_user, mission_title: '日記を投稿する')
       if result[:success]
-        flash[:daily_missions_update] =
+        flash[:daily-missions-update] =
           t('defaults.flash_message.daily_missions_updated', item: result[:message])
       end
       redirect_to diaries_path, success: t('defaults.flash_message.created', item: t('activerecord.models.diary'))

--- a/app/controllers/diaries_controller.rb
+++ b/app/controllers/diaries_controller.rb
@@ -13,6 +13,7 @@ class DiariesController < ApplicationController
 
   def create
     @diary = current_user.diaries.build(diary_params)
+    logger.debug "message::::current_user.reward result #{result}"
     if @diary.save
       result = DailyMission.update_mission(user: current_user, mission_title: '日記を投稿する')
       if result[:success]

--- a/app/controllers/likes_controller.rb
+++ b/app/controllers/likes_controller.rb
@@ -12,7 +12,7 @@ class LikesController < ApplicationController
     return unless result[:success]
 
     logger.debug 'like_count update'
-    flash[:challenge_missions_update] = t('defaults.flash_message.challenge_missions_updated', item: result[:message])
+    flash[:challenge-missions-update] = t('defaults.flash_message.challenge_missions_updated', item: result[:message])
   end
 
   def everything

--- a/app/controllers/likes_controller.rb
+++ b/app/controllers/likes_controller.rb
@@ -5,10 +5,12 @@ class LikesController < ApplicationController
   skip_before_action :verify_authenticity_token
 
   def create
+    diary = Diary.with_likes_count.find_by(id: params[:diary_id])
+    current_user.like(diary)
     @diary = Diary.with_likes_count.find_by(id: params[:diary_id])
-    current_user.like(@diary)
     result = current_user.liked_diary_count
     return unless result[:success]
+
     logger.debug 'like_count update'
     flash[:challenge_missions_update] = t('defaults.flash_message.challenge_missions_updated', item: result[:message])
   end

--- a/app/controllers/likes_controller.rb
+++ b/app/controllers/likes_controller.rb
@@ -9,10 +9,10 @@ class LikesController < ApplicationController
     current_user.like(diary)
     @diary = Diary.with_likes_count.find_by(id: params[:diary_id])
     result = current_user.liked_diary_count
-    return unless result[:success]
+    return unless result[:process]
 
     logger.debug 'like_count update'
-    flash[:challenge-missions-update] = t('defaults.flash_message.challenge_missions_updated', item: result[:message])
+    flash[:challenge_missions_update] = t('defaults.flash_message.challenge_missions_updated', item: result[:message])
   end
 
   def everything

--- a/app/controllers/ranking_controller.rb
+++ b/app/controllers/ranking_controller.rb
@@ -15,6 +15,7 @@ class RankingController < ApplicationController
   def likes_record_users
     user_likes_record_count = Like.includes(:user).group(:user_id).count
     max_likes_record = user_likes_record_count.max
+    logger.debug "message::::max_likes_record #{max_likes_record}"
     @max_likes_record_users = User.where(id: max_likes_record).select(:name, :image)
   end
 

--- a/app/models/challenge_mission.rb
+++ b/app/models/challenge_mission.rb
@@ -24,12 +24,11 @@ class ChallengeMission < ApplicationRecord
     return false unless mission
 
     user_challenge = user.user_challenges.find_by(challenge_mission_id: mission.id)
-    logger.debug "message::::user_daily #{user_challenge.inspect}"
+    logger.debug "message::::user_challenge #{user_challenge.inspect}"
     if user_challenge.present? && !user_challenge.status
-      logger.debug 'message::::user_daily.update executed'
+      logger.debug 'message::::user_challenge.update executed'
       user_challenge.update(status: true)
-      user.update_reward(mission)
-      result = user.add_buff(challenge: mission.buff, mission:)
+      result = user.add_buff(challenge: mission.buff, mission: mission)
       logger.debug "message::::add_buff result #{result}"
       if result
         logger.debug 'message::::add_buff success'

--- a/app/models/challenge_mission.rb
+++ b/app/models/challenge_mission.rb
@@ -28,6 +28,7 @@ class ChallengeMission < ApplicationRecord
     if user_challenge.present? && !user_challenge.status
       logger.debug 'message::::user_daily.update executed'
       user_challenge.update(status: true)
+      user.update_reward(mission)
       result = user.add_buff(challenge: mission.buff, mission:)
       logger.debug "message::::add_buff result #{result}"
       if result

--- a/app/models/daily_mission.rb
+++ b/app/models/daily_mission.rb
@@ -22,7 +22,7 @@ class DailyMission < ApplicationRecord
   def self.update_mission(user:, mission_title:)
     mission = find_by('title LIKE ?', "%#{mission_title}%")
     logger.debug "mission #{mission}"
-    return { success: false, message: 'Mission not found' } unless mission
+    return { process: false, message: 'Mission not found' } unless mission
 
     user_daily = user.user_dailies.find_by(daily_mission_id: mission.id)
     logger.debug "user_daily #{user_daily.inspect}"
@@ -30,10 +30,10 @@ class DailyMission < ApplicationRecord
       logger.debug 'user_daily.update executed'
       user_daily.update(status: true)
       user.add_buff(daily: mission.buff)
-      { success: true, message: mission.title }
+      { process: true, message: mission.title }
     else
       logger.debug 'mission not found or user_challenge_status is already true'
-      { success: false, message: 'Mission not found or already completed' }
+      { process: false, message: 'Mission not found or already completed' }
     end
   end
 end

--- a/app/models/daily_mission.rb
+++ b/app/models/daily_mission.rb
@@ -7,6 +7,7 @@ class DailyMission < ApplicationRecord
   validates :description, presence: true, length: { maximum: 65_535 }
 
   def self.check_record_user_dailies(user_id)
+    # Create a user daily record corresponding to the newly added daily mission. Call this upon login.
     daily_mission_ids = pluck(:id)
     existing_daily_mission_ids = UserDaily.where(user_id:,
                                                  daily_mission_id: daily_mission_ids).pluck(:daily_mission_id)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -73,19 +73,27 @@ class User < ApplicationRecord
   end
 
   def liked_diary_count
+    milestones = {
+      10 => '10個の日記にいいね',
+      50 => '50個の日記にいいね',
+      100 => '100個の日記にいいね',
+      150 => '150個の日記にいいね'
+    }
+  
     counts = likes.count
-    if counts > 10
-      result = ChallengeMission.update_mission(user: self, mission_title: '10個の日記にいいね')
-      if result
-        { success: true, message: '10個の日記にいいね' }
-      else
-        logger.debug 'message::::like_count_mission not update'
-        { success: false }
+  
+    milestones.each do |threshold, mission_title|
+      if counts > threshold
+        result = ChallengeMission.update_mission(user: self, mission_title: mission_title)
+        if result
+          return { success: true, message: mission_title }
+        else
+          logger.debug "message::::like_count_mission not update for milestone #{threshold}"
+        end
       end
-    else
-      logger.debug 'message::::like_count_mission not update'
-      { success: false }
     end
+  
+    { success: false }
   end
 
   def add_buff(daily: 0, challenge: 0, mission: nil)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -41,7 +41,7 @@ class User < ApplicationRecord
   end
 
   def set_values_by_raw_info(raw_info)
-    puts "pppppppppppppppp#{raw_info.to_json}"
+    puts "[event]#{raw_info.to_json}"
     self.raw_info = raw_info.to_json
     save!
   end
@@ -79,11 +79,11 @@ class User < ApplicationRecord
       if result
         { success: true, message: '10個の日記にいいね' }
       else
-        logger.debug 'message::::like_count not update'
+        logger.debug 'message::::like_count_mission not update'
         { success: false }
       end
     else
-      logger.debug 'message::::like_count not update'
+      logger.debug 'message::::like_count_mission not update'
       { success: false }
     end
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -90,22 +90,23 @@ class User < ApplicationRecord
 
   def add_buff(daily: 0, challenge: 0, mission: nil)
     logger.debug 'message::::add_buff executed'
-    current_buff = buff
+    logger.debug "self: #{self}"
+    logger.debug "self.buff: #{buff}"
     if daily.positive?
-      current_buff.daily_buff += daily
-      logger.debug "message::::daily_buff: #{current_buff.daily_buff}"
-      current_buff.save!
-      current_buff.sum_buff += current_buff.daily_buff
-      current_buff.save!
+      self.buff.daily_buff += daily
+      logger.debug "message::::daily_buff: #{buff.daily_buff}"
+      self.buff.save!
+      self.buff.sum_buff += buff.daily_buff
+      self.save!
       true
     elsif challenge.positive?
-      current_buff.challenge_buff += challenge
-      logger.debug "message::::challenge_buff: #{current_buff.challenge_buff}"
-      current_buff.save!
-      current_buff.sum_buff += current_buff.challenge_buff
-      current_buff.save!
-      result = update_reward(mission)
-      logger.debug "message::::update_reward result #{result}"
+      buff.challenge_buff += challenge
+      logger.debug "message::::challenge_buff: #{buff.challenge_buff}"
+      self.buff.save!
+      self.buff.sum_buff += buff.challenge_buff
+      self.save!
+      result = self.update_reward(mission)
+      logger.debug "message::::update_reward result #{self.like_css}"
       true
     else
       logger.debug 'error::::cannot add buff'
@@ -116,19 +117,19 @@ class User < ApplicationRecord
   def update_reward(mission)
     logger.debug 'message::::update_reward executed'
     logger.debug "message::::mission is #{mission.inspect}"
-    reward = self.reward
+    logger.debug "self: #{self}"
+    logger.debug "self.like_css: #{like_css}"
     if mission.like_css.present?
-      reward.like_css += mission.like_css
+      self.like_css += mission.like_css
+      self.save!
       logger.debug 'message::::like_css update'
-    end
-    if mission.diary_css.present?
-      reward.diary_css += mission.diary_css
+    elsif mission.diary_css.present?
+      diary_css += mission.diary_css
       logger.debug 'message::::diary_css update'
+    elsif mission.theme_css.present?
+      theme_css += mission.theme_css
+      logger.debug 'message::::theme_css update'
     end
-    return unless mission.theme_css.present?
-
-    reward.theme_css += mission.theme_css
-    logger.debug 'message::::theme_css update'
   end
 
   def self.ransackable_attributes(_auth_object = nil)

--- a/app/views/diaries/_diary.html.erb
+++ b/app/views/diaries/_diary.html.erb
@@ -4,7 +4,7 @@
       <% if diary.user.image.present? %>
         <%= image_tag diary.user.image %>
       <% else %>
-        <%= image_tag "https://img.daisyui.com/images/stock/photo-1534528741775-53994a69daeb.jpg", alt: "#{diary.user.name}のアバター", onerror: "this.onerror=null; this.src='/assets/avatar.png'" %>
+        <%= image_tag '/assets/avatar.png', alt: "#{diary.user.name}のアバター" %>
       <% end %>
     </div>
   </div>
@@ -43,7 +43,20 @@
       </div>
     <% end %>
     <div id="like-<%=diary.id%>" class="flex pt-3">
-      <%= diary.user.reward.like_css.inspect %>
+      <%= button_to likes_path(diary_id: diary.id), id: "btn_animation", method: { turbo_method: :post } do %>
+        <% case diary.user.like_css %>
+        <% when 0 %>
+          <i class="btnn fa-solid fa-heart text-7xl pt-2 text-green-500"></i>
+        <% when 1 %>
+          <i class="btnn fa-solid fa-heart text-7xl pt-2 text-amber-300"></i>
+        <% when 2 %>
+          <i class="btnn fa-solid fa-heart text-7xl pt-2 text-blue-500"></i>
+        <% when 3 %>
+          <i class="btnn fa-solid fa-heart text-7xl pt-2 text-rose-500"></i>
+        <% when 4 %>
+          <i class="btnn fa-solid fa-heart text-7xl pt-2 text-fuchsia-600"></i>
+        <% end %>
+      <% end %>
       <div id="count-<%= diary.id %>" class="text-base mx-7 pt-3">
         <h2><%= diary.likes_count || 0 %></h2>
       </div>

--- a/app/views/diaries/_diary.html.erb
+++ b/app/views/diaries/_diary.html.erb
@@ -43,9 +43,7 @@
       </div>
     <% end %>
     <div id="like-<%=diary.id%>" class="flex pt-3">
-      <%= button_to likes_path(diary_id: diary.id), id: "btn_animation", method: { turbo_method: :post } do %>
-        <i class="btnn fa-solid fa-heart text-5xl"></i>
-      <% end %>
+      <%= diary.user.reward.like_css.inspect %>
       <div id="count-<%= diary.id %>" class="text-base mx-7 pt-3">
         <h2><%= diary.likes_count || 0 %></h2>
       </div>

--- a/app/views/diaries/_like_everything.html.erb
+++ b/app/views/diaries/_like_everything.html.erb
@@ -1,5 +1,16 @@
 <div id="like-everything" class="tooltip tooltip-open tooltip-success" data-tip="<%= t("likes.like_everything") %>">
   <%= button_to everything_likes_path, id: "btn_animation", method: { turbo_method: :post } do %>
-    <i class="btnn fa-solid fa-heart text-7xl pt-2"></i>
+    <% case user.like_css %>
+      <% when 0 %>
+        <i class="btnn fa-solid fa-heart text-7xl pt-2 text-green-500"></i>
+      <% when 1 %>
+        <i class="btnn fa-solid fa-heart text-7xl pt-2 text-amber-300"></i>
+      <% when 2 %>
+        <i class="btnn fa-solid fa-heart text-7xl pt-2 text-blue-500"></i>
+      <% when 3 %>
+        <i class="btnn fa-solid fa-heart text-7xl pt-2 text-rose-500"></i>
+      <% when 4 %>
+        <i class="btnn fa-solid fa-heart text-7xl pt-2 text-fuchsia-600"></i>
+      <% end %>
   <% end %>
 </div>

--- a/app/views/diaries/_like_everything.html.erb
+++ b/app/views/diaries/_like_everything.html.erb
@@ -1,4 +1,4 @@
-<div id="like-everything" class="tooltip tooltip-open" data-tip="<%= t("likes.like_everything") %>">
+<div id="like-everything" class="tooltip tooltip-open tooltip-success" data-tip="<%= t("likes.like_everything") %>">
   <%= button_to everything_likes_path, id: "btn_animation", method: { turbo_method: :post } do %>
     <i class="btnn fa-solid fa-heart-circle-plus text-7xl pt-2"></i>
   <% end %>

--- a/app/views/diaries/_like_everything.html.erb
+++ b/app/views/diaries/_like_everything.html.erb
@@ -1,5 +1,5 @@
 <div id="like-everything" class="tooltip tooltip-open tooltip-success" data-tip="<%= t("likes.like_everything") %>">
   <%= button_to everything_likes_path, id: "btn_animation", method: { turbo_method: :post } do %>
-    <i class="btnn fa-solid fa-heart-circle-plus text-7xl pt-2"></i>
+    <i class="btnn fa-solid fa-heart text-7xl pt-2"></i>
   <% end %>
 </div>

--- a/app/views/diaries/_show_diary.html.erb
+++ b/app/views/diaries/_show_diary.html.erb
@@ -5,7 +5,7 @@
         <% if diary.user.image.present? %>
           <%= image_tag diary.user.image %>
         <% else %>
-          <%= image_tag "https://img.daisyui.com/images/stock/photo-1534528741775-53994a69daeb.jpg", alt: "#{diary.user.name}のアバター", onerror: "this.onerror=null; this.src='/assets/avatar.png'" %>
+          <%= image_tag '/assets/avatar.png', alt: "#{diary.user.name}のアバター" %>
         <% end %>
       </div>
     </div>

--- a/app/views/diaries/index.html.erb
+++ b/app/views/diaries/index.html.erb
@@ -2,7 +2,7 @@
 <div class="container">
   <div class="mx-5">
     <div class="row">
-      <div class="mt-3 relative z-50">
+      <div class="mt-3 relative z-30">
         <%= render 'search_form', q: @q, url: diaries_path %>
       </div>
     </div>

--- a/app/views/diaries/show.html.erb
+++ b/app/views/diaries/show.html.erb
@@ -8,7 +8,18 @@
   </div>
   <div id="like-<%=@diary.id%>" class="flex pl-20 pt-0">
     <%= button_to likes_path(diary_id: @diary.id), id: "btn_animation", method: { turbo_method: :post } do %>
-      <i class="btnn fa-solid fa-heart text-5xl"></i>
+      <% case @diary.user.like_css %>
+      <% when 0 %>
+        <i class="btnn fa-solid fa-heart text-7xl pt-2 text-green-500"></i>
+      <% when 1 %>
+        <i class="btnn fa-solid fa-heart text-7xl pt-2 text-amber-300"></i>
+      <% when 2 %>
+        <i class="btnn fa-solid fa-heart text-7xl pt-2 text-blue-500"></i>
+      <% when 3 %>
+        <i class="btnn fa-solid fa-heart text-7xl pt-2 text-rose-500"></i>
+      <% when 4 %>
+        <i class="btnn fa-solid fa-heart text-7xl pt-2 text-fuchsia-600"></i>
+      <% end %>
     <% end %>
     <div id="count-<%= @diary.id %>" class="text-base mx-7 pt-3">
       <h2><%= @diary.likes_count || 0 %></h2>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -52,7 +52,7 @@
     </div>
     <% if current_user && params[:controller] == 'diaries' && params[:action] == 'index' %>
       <div class="fixed bottom-24 right-9">
-        <%= render partial: "diaries/like_everything" %>
+        <%= render partial: "diaries/like_everything", locals: {user: current_user} %>
       </div>
     <% end %>
       <nav class="fixed h-20 bottom-0 w-full bg-wakatake text-white">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -33,7 +33,7 @@
 
   <body>
     <div class="flex flex-col min-h-screen bg-white">
-      <header class="flex justify-between bg-wakatake h-15 text-white z-40">  
+      <header class="flex justify-between bg-wakatake h-15 text-white z-50">  
         <% if user_signed_in? %>
           <%= render partial: "shared/header" %>
         <% else %>

--- a/app/views/shared/_challenge_missions.html.erb
+++ b/app/views/shared/_challenge_missions.html.erb
@@ -1,30 +1,36 @@
-<table>
-  <thead>
-    <tr>
-      <th>
-        <%= t('missions.id') %>
-      </th>
-      <th>
-        <%= t('missions.content') %>
-      </th>
-      <th>
-        <%= t('missions.status') %>
-      </th>
-    </tr>
-  </thead>
-  <tbody>
-    <% challenge_missions.each do |mission| %>
+<div class="overflow-x-auto">
+  <table class="table">
+    <thead>
       <tr>
-        <td><%= mission.id %></td>
-        <td><%= mission.title %></td>
-        <td>
-          <% if challenge_status[mission.id]&.status %>
-            <%= t('missions.true') %>
-          <% else %>
-            <%= t('missions.false') %>
-          <% end %>
-        </td>
+        <th>
+          <%= t('missions.id') %>
+        </th>
+        <th>
+          <%= t('missions.content') %>
+        </th>
+        <th>
+          <%= t('missions.status') %>
+        </th>
       </tr>
-    <% end %>
-  </tbody>
-</table>
+    </thead>
+    <tbody>
+      <% challenge_missions.each do |mission| %>
+        <tr>
+          <td><%= mission.id %></td>
+          <td><%= mission.title %></td>
+          <td>
+            <% if challenge_status[mission.id]&.status %>
+              <div class="font-bold text-green-500">
+                <%= t('missions.true') %>
+              </div>
+            <% else %>
+              <div class="font-bold">
+                <%= t('missions.false') %>
+              </div>
+            <% end %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/app/views/shared/_daily_missions.html.erb
+++ b/app/views/shared/_daily_missions.html.erb
@@ -1,30 +1,36 @@
-<table>
-  <thead>
-    <tr>
-      <th>
-        <%= t('missions.id') %>
-      </th>
-      <th>
-        <%= t('missions.content') %>
-      </th>
-      <th>
-        <%= t('missions.status') %>
-      </th>
-    </tr>
-  </thead>
-  <tbody>
-    <% daily_missions.each do |mission| %>
+<div class="overflow-x-auto">
+  <table class="table">
+    <thead>
       <tr>
-        <td><%= mission.id %></td>
-        <td><%= mission.title %></td>
-        <td>
-          <% if daily_status[mission.id]&.status %>
-            <%= t('missions.true') %>
-          <% else %>
-            <%= t('missions.false') %>
-          <% end %>
-        </td>
+        <th>
+          <%= t('missions.id') %>
+        </th>
+        <th>
+          <%= t('missions.content') %>
+        </th>
+        <th>
+          <%= t('missions.status') %>
+        </th>
       </tr>
-    <% end %>
-  </tbody>
-</table>
+    </thead>
+    <tbody>
+      <% daily_missions.each do |mission| %>
+        <tr>
+          <td><%= mission.id %></td>
+          <td><%= mission.title %></td>
+          <td>
+            <% if daily_status[mission.id]&.status %>
+              <div class="font-bold text-green-500">
+                <%= t('missions.true') %>!
+              </div>
+            <% else %>
+              <div class="font-bold">
+                <%= t('missions.false') %>
+              </div>
+            <% end %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -71,7 +71,7 @@
 <dialog id="my_modal_1" class="modal">
   <div class="modal-box bg-white text-black">
     <h3 class="text-lg font-bold">デイリーミッション</h3>
-    <div class="text-lg">毎日クリアするたびにバフUP!</div>
+    <div class="text-lg">毎日クリアするたびにいいね獲得数UP!</div>
     <div id="mission-list-daily" class="mt-4">
       <!-- デイリーミッション一覧はここに表示されます -->
     </div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -71,6 +71,7 @@
 <dialog id="my_modal_1" class="modal">
   <div class="modal-box bg-white text-black">
     <h3 class="text-lg font-bold">デイリーミッション</h3>
+    <div class="text-lg">毎日クリアするたびにバフUP!</div>
     <div id="mission-list-daily" class="mt-4">
       <!-- デイリーミッション一覧はここに表示されます -->
     </div>

--- a/db/migrate/20240824175619_add_column_css_to_user.rb
+++ b/db/migrate/20240824175619_add_column_css_to_user.rb
@@ -1,0 +1,7 @@
+class AddColumnCssToUser < ActiveRecord::Migration[7.1]
+  def change
+    add_column :users, :like_css, :integer, default: 0
+    add_column :users, :diary_css, :integer, default: 0
+    add_column :users, :theme_css, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_08_11_103522) do
+ActiveRecord::Schema[7.1].define(version: 2024_08_24_175619) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -117,6 +117,9 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_11_103522) do
     t.string "name"
     t.boolean "remind", default: false
     t.string "image"
+    t.integer "like_css", default: 0
+    t.integer "diary_css", default: 0
+    t.integer "theme_css", default: 0
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -10,18 +10,18 @@
 #     MovieGenre.find_or_create_by!(name: genre_name)
 #   end
 
-5.times do
-  user = User.create!(name: Faker::Name.name,
-                      email: Faker::Internet.unique.email,
-                      password: 'password',
-                      password_confirmation: 'password')
-  puts "\"#{user.name}\" has created!"
-end
+# 5.times do
+#   user = User.create!(name: Faker::Name.name,
+#                       email: Faker::Internet.unique.email,
+#                       password: 'password',
+#                       password_confirmation: 'password')
+#   puts "\"#{user.name}\" has created!"
+# end
 
 User.ids
 
-# 4.times do |index|
-#   user = User.find(user_ids.sample)
-#   diary = user.diaries.create!(title: "今日は連勤#{index}日目だった", body: "まだまだ#{index}日ぐらい頑張れそう！", diary_date: Date.today)
-#   puts "\"#{diary.title}\" has created!"
-# end
+10.times do |index|
+  user = User.find(11)
+  diary = user.diaries.create!(title: "今日は連勤#{index}日目だった", body: "まだまだ#{index}日ぐらい頑張れそう！", diary_date: Date.today)
+  puts "\"#{diary.title}\" has created!"
+end


### PR DESCRIPTION
## 概要
* いいねした日記の数に応じてチャレンジミッションが達成され、自分のハートマークの色が変化するように修正
* いいねに関するチャレンジミッションの更新は、いいねの処理が非同期なので達成時にフラッシュメッセージを表示することはできない。別ページに遷移した場合などのリダイレクトした場合に表示されるようになっているが、現状はこの仕様で良しとする。
* チャレンジミッションを3個追加(50, 100, 150個の日記にいいねする)→当初は100,1000,10000だったのを軌道修正
* デイリーミッションにコメントを作成する　を追加
* user.rbのメソッドをリファクタリング

## 詳細
ミッションの処理は以下の流れ
1. デイリーミッションモデルのupdate_missionメソッドに、userの情報と達成させたいミッションタイトルを渡す
2. update_missionメソッドでは、まず一致検索でdaily_missionのレコードを取得する。
3. 次に、渡されたユーザー情報(current_user)と関連づけられたデイリーミッションとの中間テーブル(user_dailies)の中から、missionのidが一致するレコードを探す
4. user_dailiesのレコードがある且つ、そのuser_dailiesレコードのstatusがfalse(未達成)の場合のみ条件分岐に遷移する。
　その中ではuser_dailyのstatusカラムをtrueにして達成済にする処理の後にuserモデルの
　add_buffメソッドを呼び出す。(user.にはcurrent_userが入っている)

5. add_buffでは、デイリーミッションのレコードに入っているbuffカラムの値分、
    ユーザーと1対1で関連づけられているbuffレコードのdaily_buffに追加する処理が走る。
　このadd_buffメソッドは、デイリーミッションやチャレンジミッションの達成に応じて
　ユーザーのバフを増加させる重要な役割を果たしています。デイリーミッションの場合、
　daily_buffが増加し、チャレンジミッションの場合はchallenge_buffが増加します。
　どちらの場合も、最終的にsum_buffに反映され、ユーザーの総バフ値が更新される。

6. チャレンジミッションの場合、add_buffの条件分岐で同じくuser.rb内のインスタンスメソッドupdate_cssメソッドを呼び出す。このupdate_cssメソッドでは、達成したミッションに応じて、ユーザーの特定のCSSポイントを増加させる。例えば、いいねの見た目を変更するチャレンジミッションを達成した場合、like_cssポイントが増加する。これにより、ユーザーは新しい見た目のオプションをアンロックすることができる。

7. add_buff(とupdate_buff)、update_cssが処理された後、update_missionに戻ってくる。ここで、update_missionメソッドは成功または失敗のステータスと、ミッションのタイトルまたはエラーメッセージを含むハッシュを返します。この返り値は、コントローラーでflashメッセージを設定するために使用されます。最後に、コントローラーでこの返り値を受け取り、適切なflashメッセージを設定することで、ユーザーにミッション達成の通知を表示します。これにより、ユーザーは自分の進捗状況を視覚的に確認することができます。

* いいねした日記の数に応じたミッションの更新処理は、user.rbのliked_diary_count処理で実施する。
![image](https://github.com/user-attachments/assets/f00e5bdc-5c1d-43cb-ac11-ec3a0e6b517f)
