### PR TITLE
fix: diaries_controllerのcreateアクションにあった余計なログ出力処理削除

### DIFF
--- a/app/controllers/diaries_controller.rb
+++ b/app/controllers/diaries_controller.rb
@@ -13,7 +13,6 @@ class DiariesController < ApplicationController
 
   def create
     @diary = current_user.diaries.build(diary_params)
-    logger.debug "message::::current_user.reward result #{result}"
     if @diary.save
       result = DailyMission.update_mission(user: current_user, mission_title: '日記を投稿する')
       if result[:process]


### PR DESCRIPTION
## 概要
* 日記作成のcreateアクションに余計なログ処理があったせいで日記作成ができなくなっていたので、削除して改善

```ruby
def create
    @diary = current_user.diaries.build(diary_params)
    logger.debug(message::::::::curent_user.reward result: #{result}) ←これがなぜか追加されていたので削除
    if @diary.save
```